### PR TITLE
 [FEATURE] Auto 모드에서 Agent 프롬프트 전달 API

### DIFF
--- a/backend_server.py
+++ b/backend_server.py
@@ -10,5 +10,13 @@ def receive_agent_output():
 
     return '', 200
 
+@app.route('/agent/list', methods=['POST'])
+def receive_agent_list():
+    data = request.json
+    print("Received agent list:")
+    print(data)
+
+    return '', 200
+
 if __name__ == '__main__':
     app.run(port=8000)


### PR DESCRIPTION
## #️⃣ Issue Number
<!-- ex) - #이슈번호 -->
- #8 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

Auto 모드에서 생성된 에이전트 리스트를 백엔드에 전송하는 기능을 구현하고, 관련 URL 처리 로직을 리팩토링했습니다.

1.  **에이전트 리스트 전송 기능 추가**
    - AgentOrchestrator에 _send_agent_list 메서드를 추가하여 생성된 에이전트 정보(`name`, `role`, `prompt`)를 백엔드(`/agent/list`)로 전송하도록 구현했습니다.
    - run_workflow 실행 시 `Auto 모드`인 경우 에이전트 생성 직후 해당 리스트를 전송합니다.
2.  **URL 핸들링 리팩토링**
    - `BACKEND_URL` 뒤에 붙는 경로들을 상수(`ENDPOINT_AGENT_RESULT`, `ENDPOINT_AGENT_LIST`)로 분리하여 관리하도록 개선했습니다.
    - [_send_to_backend](cci:1://file:///Users/yeseul/projects/took/took_ai/main.py:104:4-124:48) 및 [_send_agent_list](cci:1://file:///Users/yeseul/projects/took/took_ai/main.py:126:4-146:52) 메서드에서 `base_url`과 상수를 조합하여 요청을 보내도록 변경했습니다.
3.  **테스트용 백엔드 서버 업데이트**
    - [backend_server.py](cci:7://file:///Users/yeseul/projects/took/took_ai/backend_server.py:0:0-0:0)에 `/agent/list` 엔드포인트를 추가하여 전송된 데이터를 로그로 확인할 수 있도록 했습니다.
## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 에이전트 리스트 전송 실패 시 전체 로직이 중단되지 않고 로그만 남기도록 예외 처리를 했습니다 (`[Agent List 전송 실패]`). 이후 재시도하는 로직을 추가하는 게 좋을까요?
## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)