### PR TITLE
[FEATURE] AI 서버 포트 번호 변경 5001 -> 5050

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 # 포트 노출 (uvicorn 기본 포트)
-EXPOSE 5000
+EXPOSE 5050
 
 # 애플리케이션 실행
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "5000"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "5050"]

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ docker-compose down
 
 ## API 사용 가이드
 
-서버가 실행되면 **5001번 포트**를 통해 접근할 수 있습니다.
+서버가 실행되면 **5050번 포트**를 통해 접근할 수 있습니다.
 
-- **Base URL**: `http://localhost:5001`
-- **Swagger UI**: `http://localhost:5001/docs` (API 문서 및 테스트)
+- **Base URL**: `http://localhost:5050`
+- **Swagger UI**: `http://localhost:5050/docs` (API 문서 및 테스트)
 
 ## 로컬 환경 실행
 
@@ -62,5 +62,5 @@ pip install -r requirements.txt
 
 3. 서버 실행
 ```bash
-uvicorn main:app --reload --port 5001
+uvicorn main:app --reload --port 5050
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   agent-app:
     build: .
     ports:
-      - "5001:5000"
+      - "5050:5050"
     volumes:
       - .:/app
     environment:

--- a/main.py
+++ b/main.py
@@ -308,4 +308,4 @@ async def continue_agents(request: AgentReplyRequest):
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="127.0.0.1", port=5000)
+    uvicorn.run(app, host="127.0.0.1", port=5050)


### PR DESCRIPTION
## #️⃣ Issue Number
<!-- ex) - #이슈번호 -->
- #14 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
AI 서버의 실행하는 포트 번호를 `5050`으로 변경했습니다.
기존에 도커 사용할 때 5001:5000으로 포트 매핑했는데, 로컬로도 자주 실행해서 포트 번호 통일하는 게 좋을 것 같아서 바꿨습니다.

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 백엔드에서 보내는 포트도 변경 부탁드립니다!
- 전체 실행할 때도 포트 한번만 확인해주세요.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)